### PR TITLE
Fixed NPE when code minings are enabled and the editor closed

### DIFF
--- a/org.eclipse.xtext.ui.codemining/src/org/eclipse/xtext/ui/codemining/AbstractXtextCodeMiningProvider.java
+++ b/org.eclipse.xtext.ui.codemining/src/org/eclipse/xtext/ui/codemining/AbstractXtextCodeMiningProvider.java
@@ -27,6 +27,7 @@ import org.eclipse.jface.text.codemining.LineContentCodeMining;
 import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.IAcceptor;
@@ -87,7 +88,11 @@ public abstract class AbstractXtextCodeMiningProvider extends AbstractCodeMining
 				}
 
 			};
-			return xtextDocumentUtil.getXtextDocument(viewer).tryReadOnly(uow, () -> Collections.emptyList());
+			IXtextDocument xtextDocument = xtextDocumentUtil.getXtextDocument(viewer);
+			if (xtextDocument == null) {
+				return Collections.emptyList();
+			}
+			return xtextDocument.tryReadOnly(uow, () -> Collections.emptyList());
 		});
 		return future;
 	}


### PR DESCRIPTION
pr_rerun QDinsight:fix_NPE_when_editor_is_closed_and_the_worker_thread_asks_for_doc to main